### PR TITLE
arrumei pequeno erro na asserção

### DIFF
--- a/doqueru.cpp
+++ b/doqueru.cpp
@@ -180,7 +180,7 @@ void config(size_t argc, char** argv) {
             configs[c].value = from_cstr(temp);
             configs[c++].controller = "memory/";
             mem_max = strtoul(temp, NULL, 0);
-            ASSERT(cpu_percent > 0);
+            ASSERT(mem_max > 0);
             printf("MEM_MAX is set to %lu\n", mem_max);
         }
         else


### PR DESCRIPTION
Na hora de ler mem_max, o programa estava verificando se cpu_percent era maior do que zero. O adequado seria verificar mem_max, o valor realmente lido.